### PR TITLE
Store S3 keys; generate signed URLs on demand (Closes #19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pnpm-debug.log*
 .turbo/
 .prisma
 .next/
+.nx/

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -16,7 +16,11 @@
     "rules": {
       "recommended": true,
       "suspicious": {
-        "noExplicitAny": "error"
+        "noExplicitAny": "error",
+        "noEmptyBlockStatements": "error"
+      },
+      "complexity": {
+        "noUselessCatch": "error"
       },
       "a11y": {
         "useKeyWithClickEvents": "off"

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "@am-crm/shared": "workspace:*",
         "@aws-sdk/client-s3": "^3.882.0",
         "@aws-sdk/s3-request-presigner": "^3.882.0",
+        "@elumixor/di": "^0.2.4",
         "@elumixor/frontils": "^2.14.1",
         "@prisma/client": "^5.18.0",
         "hono": "^4.4.7",
@@ -183,6 +184,8 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.2.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-wBe2wItayw1zvtXysmHJQoQqXlTzHSpQRyPpJKiNIR21HzH/CrZRDFic1C1jDdp+zAPtqhNExa0owKMbNwW9cQ=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-DAuHhHekGfiGb6lCcsT4UyxQmVwQiBCBUMwVra/dcOSs9q8OhfaZgey51MlekT3p8UwRqtXQfFuEJBhJNdLZwg=="],
+
+    "@elumixor/di": ["@elumixor/di@0.2.4", "", {}, "sha512-+qA+FXdF/ioPkMLffAu617b+WDVPb5qBZ8zVax6IQZclkEhb+bfpf4DlzNJp2z+QrEjX6JdkbyIeeHFqgama8A=="],
 
     "@elumixor/frontils": ["@elumixor/frontils@2.14.1", "", {}, "sha512-IeJvXwS/vhLq6O1CBeEfHW7OMgpGz4HDZPXGToDr8huvcardCBZZDZvqoWQ15pW/WnCdkpOk7AX0yGCR/LFLqQ=="],
 
@@ -390,6 +393,8 @@
 
     "dotenv-expand": ["dotenv-expand@11.0.7", "", { "dependencies": { "dotenv": "^16.4.5" } }, "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA=="],
 
+    "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
+
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
     "fast-xml-parser": ["fast-xml-parser@5.2.5", "", { "dependencies": { "strnum": "^2.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ=="],
@@ -401,6 +406,8 @@
     "happy-dom": ["happy-dom@18.0.1", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA=="],
 
     "hono": ["hono@4.9.4", "", {}, "sha512-61hl6MF6ojTl/8QSRu5ran6GXt+6zsngIUN95KzF5v5UjiX/xnrLR358BNRawwIRO49JwUqJqQe3Rb2v559R8Q=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
@@ -447,6 +454,8 @@
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
     "safe-compare": ["safe-compare@1.1.4", "", { "dependencies": { "buffer-alloc": "^1.2.0" } }, "sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "sandwich-stream": ["sandwich-stream@2.0.2", "", {}, "sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "biome lint",
     "format": "biome format --write",
     "migrate": "dotenv -e .env -- turbo db:migrate",
+    "migrate:deploy": "dotenv -e .env -- turbo db:migrate:deploy",
     "generate": "dotenv -e .env -- turbo db:generate"
   },
   "devDependencies": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "dev": "bun run src/index.ts",
+    "dev": "bun run src/index.ts --watch",
     "build": "bun build --target bun ./src/index.ts --outdir dist",
     "test": "bun test"
   },
@@ -12,6 +12,7 @@
     "@am-crm/shared": "workspace:*",
     "@aws-sdk/client-s3": "^3.882.0",
     "@aws-sdk/s3-request-presigner": "^3.882.0",
+    "@elumixor/di": "^0.2.4",
     "@elumixor/frontils": "^2.14.1",
     "@prisma/client": "^5.18.0",
     "hono": "^4.4.7"

--- a/packages/api/src/app/app.ts
+++ b/packages/api/src/app/app.ts
@@ -1,11 +1,13 @@
+import { di } from "@elumixor/di";
 import { PrismaClient } from "@prisma/client";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { S3Service } from "./s3";
+import { AWSUploadService } from "../utils/aws-upload-service";
 
+@di.injectable
 export class App extends Hono {
   readonly prisma = new PrismaClient();
-  readonly s3 = new S3Service();
+  readonly uploadService = new AWSUploadService();
 
   private allowedOrigins = [process.env.FRONT_LOCAL_URL, process.env.FRONT_PROD_URL, process.env.FRONT_DEV_URL];
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,4 +1,4 @@
-import { App } from "./app";
+import { App } from "./app/app";
 import { registerAuthRoutes } from "./routes/auth";
 import { registerBaseRoutes } from "./routes/base";
 import { registerProfileRoutes } from "./routes/profile";

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1,7 +1,7 @@
+import { randomUUID } from "node:crypto";
 import type { LoginPayload, RegisterPayload, ResetPasswordPayload } from "@am-crm/shared";
-import { randomUUID } from "crypto";
 import type { Context } from "hono";
-import type { App } from "../app";
+import type { App } from "../app/app";
 
 // In-memory session store (MVP only)
 const sessions = new Map<string, string>(); // token -> userId

--- a/packages/api/src/routes/base.ts
+++ b/packages/api/src/routes/base.ts
@@ -1,6 +1,6 @@
-import type { Hono } from "hono";
+import type { App } from "../app/app";
 
-export const registerBaseRoutes = (app: Hono) => {
+export const registerBaseRoutes = (app: App) => {
   app.get("/", (c) => c.json({ ok: true }));
   // Lightweight health / liveness endpoint (no DB dependency)
   app.get("/health", (c) => c.json({ status: "ok" }));

--- a/packages/api/src/routes/units.ts
+++ b/packages/api/src/routes/units.ts
@@ -1,5 +1,5 @@
 import type { CreateUnitPayload, UpdateUnitPayload } from "@am-crm/shared";
-import type { App } from "../app";
+import type { App } from "../app/app";
 import { mapUnit, mapUser } from "../utils/mappers";
 
 export const registerUnitRoutes = (app: App) => {

--- a/packages/api/src/utils/mappers.ts
+++ b/packages/api/src/utils/mappers.ts
@@ -1,5 +1,7 @@
 import type { LessonProgress, Unit as UnitDTO, User as UserDTO, UserTrait as UserTraitDTO } from "@am-crm/shared";
+import { di } from "@elumixor/di";
 import type { Unit as PrismaUnit, User as PrismaUser, UserTrait as PrismaUserTrait } from "@prisma/client";
+import { AWSUploadService } from "./aws-upload-service";
 
 export const mapTrait = (t: PrismaUserTrait): UserTraitDTO => ({ id: t.id, userId: t.userId, trait: t.trait });
 
@@ -11,30 +13,31 @@ type ExtendedPrismaUser = PrismaUser &
     initiates: PrismaUser[];
   }>;
 
-export const mapUser = (u: ExtendedPrismaUser): UserDTO => ({
-  id: u.id,
-  email: u.email,
-  fullName: u.fullName ?? null,
-  spiritualName: u.spiritualName ?? null,
-  displayName: u.displayName ?? null,
-  telegramHandle: u.telegramHandle ?? null,
-  whatsapp: u.whatsapp ?? null,
-  photoUrl: u.photoUrl ?? null,
-  dateOfBirth: u.dateOfBirth ? u.dateOfBirth.toISOString() : null,
-  nationality: u.nationality ?? null,
-  languages: u.languages ?? null,
-  location: u.location ?? null,
-  preferredLanguage: u.preferredLanguage ?? null,
-  unitId: u.unitId ?? null,
-  mentorId: u.mentorId ?? null,
-  acaryaId: (u as PrismaUser).acaryaId ?? null,
-  menteeIds: (u.mentees ?? []).map((m) => m.id),
-  initiateIds: (u.initiates ?? []).map((m) => m.id),
-  lessons: Array.isArray((u as unknown as { lessons?: unknown }).lessons)
-    ? (u as unknown as { lessons: LessonProgress[] }).lessons
-    : [],
-  traits: (u.traits ?? []).map(mapTrait),
-});
+export async function mapUser(u: ExtendedPrismaUser): Promise<UserDTO> {
+  return {
+    id: u.id,
+    email: u.email,
+    fullName: u.fullName,
+    spiritualName: u.spiritualName,
+    displayName: u.displayName,
+    telegramHandle: u.telegramHandle,
+    whatsapp: u.whatsapp,
+    // Do not expose DB key; routes will generate a signed URL per request if a photoKey exists
+    photoUrl: u.photoKey ? await di.inject(AWSUploadService).getSignedUrl(u.photoKey) : null,
+    dateOfBirth: u.dateOfBirth ? u.dateOfBirth.toISOString() : null,
+    nationality: u.nationality,
+    languages: u.languages,
+    location: u.location,
+    preferredLanguage: u.preferredLanguage,
+    unitId: u.unitId,
+    mentorId: u.mentorId,
+    acaryaId: u.acaryaId,
+    menteeIds: (u.mentees ?? []).map((m) => m.id),
+    initiateIds: (u.initiates ?? []).map((m) => m.id),
+    lessons: Array.isArray(u.lessons) ? (u as unknown as { lessons: LessonProgress[] }).lessons : [],
+    traits: (u.traits ?? []).map(mapTrait),
+  };
+}
 
 export const mapUnit = (u: PrismaUnit): UnitDTO => ({
   id: u.id,
@@ -42,5 +45,5 @@ export const mapUnit = (u: PrismaUnit): UnitDTO => ({
   description: u.description,
   unofficialRegisteredAt: u.unofficialRegisteredAt ? u.unofficialRegisteredAt.toISOString() : null,
   officialRegisteredAt: u.officialRegisteredAt ? u.officialRegisteredAt.toISOString() : null,
-  userIds: [], // populated separately when needed
+  userIds: [],
 });

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "db:up": "docker compose -f ./docker-compose.yml up -d db",
     "db:migrate": "prisma migrate dev --name init",
+    "db:migrate:deploy": "prisma migrate deploy",
     "db:generate": "prisma generate",
     "test": "bun test"
   },

--- a/packages/db/prisma/migrations/20250906231453_init/migration.sql
+++ b/packages/db/prisma/migrations/20250906231453_init/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `photoUrl` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "photoUrl",
+ADD COLUMN     "photoKey" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -22,7 +22,7 @@ model User {
   displayName       String?
   telegramHandle    String?
   whatsapp          String?
-  photoUrl          String?
+  photoKey          String?
   dateOfBirth       DateTime?
   nationality       String?
   languages         String?

--- a/packages/web/app/profile/page.tsx
+++ b/packages/web/app/profile/page.tsx
@@ -61,9 +61,18 @@ export default function ProfilePage() {
       router.replace("/login");
       return;
     }
+
     // Load profile
     (async () => {
       const res = await fetch(`${apiBase}/me`, { headers: { authorization: `Bearer ${token}` } });
+
+      if (res.status === 401) {
+        // Session expired or backend has no session for this token
+        localStorage.removeItem("session");
+        router.replace("/login");
+        return;
+      }
+
       if (res.ok) setUser(await res.json());
       const unitsRes = await fetch(`${apiBase}/units`);
       if (unitsRes.ok) setUnits(await unitsRes.json());

--- a/packages/web/app/register/page.tsx
+++ b/packages/web/app/register/page.tsx
@@ -1,7 +1,8 @@
 "use client";
+
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useAuth } from "../../components/AuthContext";
-import { useRouter } from "next/navigation";
 
 export default function RegisterPage() {
   const { register, loading, token } = useAuth();

--- a/packages/web/app/users/[id]/page.tsx
+++ b/packages/web/app/users/[id]/page.tsx
@@ -1,8 +1,8 @@
 "use client";
-import { useParams, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import { useAuth } from "../../../components/AuthContext";
+
 import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
 import { EntityChip } from "../../../components/EntityChip";
 
 interface UserDto {

--- a/packages/web/app/users/page.tsx
+++ b/packages/web/app/users/page.tsx
@@ -39,10 +39,8 @@ export default function UsersPage() {
   }, [apiBase]);
 
   const fetchUnits = useCallback(async () => {
-    try {
-      const res = await fetch(`${apiBase}/units`);
-      if (res.ok) setUnits(await res.json());
-    } catch {}
+    const res = await fetch(`${apiBase}/units`);
+    if (res.ok) setUnits(await res.json());
   }, [apiBase]);
 
   // Create user

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -4,9 +4,9 @@
     "DATABASE_URL",
     "API_BASE_URL",
     "NEXT_PUBLIC_API_BASE_URL",
-    "LOCAL_FRONTEND_URL",
-    "VERCEL_PROD_URL",
-    "VERCEL_DEV_URL",
+    "FRONT_LOCAL_URL",
+    "FRONT_PROD_URL",
+    "FRONT_DEV_URL",
     "AWS_REGION",
     "AWS_BUCKET_NAME",
     "AWS_ACCESS_KEY_ID",
@@ -17,9 +17,15 @@
     "db:up": { "cache": false, "outputs": [] },
     // Runs database migrations
     "db:migrate": { "dependsOn": ["db:up"], "cache": false, "outputs": [] },
+    "db:migrate:deploy": { "dependsOn": ["db:up"], "cache": false, "outputs": [] },
     "db:generate": { "dependsOn": ["db:up"], "cache": false, "outputs": [] },
     // Runs dev commands in all packages (basically api (back-end) and web (front-end))
-    "dev": { "dependsOn": ["db:migrate"], "cache": false, "outputs": [] },
+    "dev": {
+      "dependsOn": ["db:migrate"],
+      "cache": false,
+      "outputs": [],
+      "env": ["FRONT_LOCAL_URL", "FRONT_PROD_URL", "FRONT_DEV_URL"]
+    },
     // Builds everything
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
This PR implements the image handling change per #19.

Summary
- DB: rename User.photoUrl -> User.photoKey and store only the S3 object key.
- API:
  - Upload: save key, return fresh presigned URL.
  - Read: generate presigned URL per request for users/me, user list and detail.
  - S3 service: upload no longer returns URL; getSignedUrl used on demand.
- Web: continues to consume photoUrl coming from API; now always fresh.

Notes
- Prisma migration added; run migration + generate locally with DATABASE_URL set.

Closes #19